### PR TITLE
opentracing: make HTTP header prefix constants more readable

### DIFF
--- a/opentracing/utils.go
+++ b/opentracing/utils.go
@@ -7,12 +7,13 @@ import (
 )
 
 const (
-	// OpenTracingContextIDHTTPHeaderPrefix precedes the opentracing-related
-	// ContextID HTTP headers.
-	OpenTracingContextIDHTTPHeaderPrefix = "Open-Tracing-Context-Id-"
-	// OpenTracingTagsHTTPHeaderPrefix precedes the opentracing-related
-	// trace-tags HTTP headers.
-	OpenTracingTagsHTTPHeaderPrefix = "Open-Tracing-Trace-Tags-"
+	// ContextIDHTTPHeaderPrefix precedes the opentracing-related ContextID HTTP
+	// headers.
+	ContextIDHTTPHeaderPrefix = "Open-Tracing-Context-Id-"
+
+	// TagsHTTPHeaderPrefix precedes the opentracing-related trace-tags HTTP
+	// headers.
+	TagsHTTPHeaderPrefix = "Open-Tracing-Trace-Tags-"
 )
 
 // AddTraceContextToHeader marshals TraceContext `ctx` to `h` as a series of
@@ -24,10 +25,10 @@ func AddTraceContextToHeader(
 ) {
 	contextIDMap, tagsMap := marshaler.MarshalTraceContextStringMap(ctx)
 	for headerSuffix, val := range contextIDMap {
-		h.Add(OpenTracingContextIDHTTPHeaderPrefix+headerSuffix, url.QueryEscape(val))
+		h.Add(ContextIDHTTPHeaderPrefix+headerSuffix, url.QueryEscape(val))
 	}
 	for headerSuffix, val := range tagsMap {
-		h.Add(OpenTracingTagsHTTPHeaderPrefix+headerSuffix, url.QueryEscape(val))
+		h.Add(TagsHTTPHeaderPrefix+headerSuffix, url.QueryEscape(val))
 	}
 }
 
@@ -40,20 +41,20 @@ func TraceContextFromHeader(
 	contextIDMap := make(map[string]string)
 	tagsMap := make(map[string]string)
 	for key, val := range h {
-		if strings.HasPrefix(key, OpenTracingContextIDHTTPHeaderPrefix) {
+		if strings.HasPrefix(key, ContextIDHTTPHeaderPrefix) {
 			// We don't know what to do with anything beyond slice item v[0]:
 			unescaped, err := url.QueryUnescape(val[0])
 			if err != nil {
 				return nil, err
 			}
-			contextIDMap[strings.TrimPrefix(key, OpenTracingContextIDHTTPHeaderPrefix)] = unescaped
-		} else if strings.HasPrefix(key, OpenTracingTagsHTTPHeaderPrefix) {
+			contextIDMap[strings.TrimPrefix(key, ContextIDHTTPHeaderPrefix)] = unescaped
+		} else if strings.HasPrefix(key, TagsHTTPHeaderPrefix) {
 			// We don't know what to do with anything beyond slice item v[0]:
 			unescaped, err := url.QueryUnescape(val[0])
 			if err != nil {
 				return nil, err
 			}
-			tagsMap[strings.TrimPrefix(key, OpenTracingTagsHTTPHeaderPrefix)] = unescaped
+			tagsMap[strings.TrimPrefix(key, TagsHTTPHeaderPrefix)] = unescaped
 		}
 
 	}


### PR DESCRIPTION
- Remove `OpenTracing` prefix as the package is already `opentracing`.
- Add some whitespace between the comments.