### PR TITLE
opentracing/ext: simplify internal tag types

### DIFF
--- a/opentracing/ext/tags.go
+++ b/opentracing/ext/tags.go
@@ -9,44 +9,38 @@ var (
 	// the other side/service in a peer-to-peer communications, like an RPC call.
 
 	// PeerService records the service name of the peer
-	PeerService = &stringTag{"peer.service"}
+	PeerService = stringTag("peer.service")
 
 	// PeerHostname records the host name of the peer
-	PeerHostname = &stringTag{"peer.hostname"}
+	PeerHostname = stringTag("peer.hostname")
 
 	// PeerHostIPv4 records IP v4 host address of the peer
-	PeerHostIPv4 = &uint32Tag{"peer.ipv4"}
+	PeerHostIPv4 = uint32Tag("peer.ipv4")
 
 	// PeerHostIPv6 records IP v6 host address of the peer
-	PeerHostIPv6 = &stringTag{"peer.ipv6"}
+	PeerHostIPv6 = stringTag("peer.ipv6")
 
 	// PeerPort records port number of the peer
-	PeerPort = &uint16Tag{"peer.port"}
+	PeerPort = uint16Tag("peer.port")
 )
 
-type stringTag struct {
-	Key string
-}
+type stringTag string
 
 // Add adds a string tag to the `span`
-func (tag *stringTag) Add(span opentracing.Span, value string) {
-	span.SetTag(tag.Key, value)
+func (tag stringTag) Add(span opentracing.Span, value string) {
+	span.SetTag(string(tag), value)
 }
 
-type uint32Tag struct {
-	Key string
-}
+type uint32Tag string
 
 // Add adds a uint32 tag to the `span`
-func (tag *uint32Tag) Add(span opentracing.Span, value uint32) {
-	span.SetTag(tag.Key, value)
+func (tag uint32Tag) Add(span opentracing.Span, value uint32) {
+	span.SetTag(string(tag), value)
 }
 
-type uint16Tag struct {
-	Key string
-}
+type uint16Tag string
 
 // Add adds a uint16 tag to the `span`
-func (tag *uint16Tag) Add(span opentracing.Span, value uint16) {
-	span.SetTag(tag.Key, value)
+func (tag uint16Tag) Add(span opentracing.Span, value uint16) {
+	span.SetTag(string(tag), value)
 }

--- a/opentracing/ext/tags_test.go
+++ b/opentracing/ext/tags_test.go
@@ -10,8 +10,8 @@ import (
 )
 
 func TestPeerTags(t *testing.T) {
-	if ext.PeerService.Key != "peer.service" {
-		t.Fatalf("Invalid PeerService.Key %v", ext.PeerService.Key)
+	if ext.PeerService != "peer.service" {
+		t.Fatalf("Invalid PeerService %v", ext.PeerService)
 	}
 	recorder := testutils.NewInMemoryRecorder("test-process")
 	tracer := standardtracer.New(recorder, &testutils.SimpleTraceContextSource{})
@@ -26,9 +26,9 @@ func TestPeerTags(t *testing.T) {
 		t.Fatal("Span not recorded")
 	}
 	rawSpan := recorder.GetSpans()[0]
-	assert.EqualValues(t, "my-service", rawSpan.Tags[ext.PeerService.Key])
-	assert.EqualValues(t, "my-hostname", rawSpan.Tags[ext.PeerHostname.Key])
-	assert.EqualValues(t, uint32(127<<24|1), rawSpan.Tags[ext.PeerHostIPv4.Key])
-	assert.EqualValues(t, "::", rawSpan.Tags[ext.PeerHostIPv6.Key])
-	assert.EqualValues(t, 8080, rawSpan.Tags[ext.PeerPort.Key])
+	assert.EqualValues(t, "my-service", rawSpan.Tags[string(ext.PeerService)])
+	assert.EqualValues(t, "my-hostname", rawSpan.Tags[string(ext.PeerHostname)])
+	assert.EqualValues(t, uint32(127<<24|1), rawSpan.Tags[string(ext.PeerHostIPv4)])
+	assert.EqualValues(t, "::", rawSpan.Tags[string(ext.PeerHostIPv6)])
+	assert.EqualValues(t, 8080, rawSpan.Tags[string(ext.PeerPort)])
 }


### PR DESCRIPTION
  - No need for struct because there is only one field.
  - Do not place the values on the heap / use pointer as they are small.